### PR TITLE
Improve Makefile cross-platform compatibility

### DIFF
--- a/firmware-template-gd32/Rules.mk
+++ b/firmware-template-gd32/Rules.mk
@@ -137,4 +137,4 @@ $(foreach bdir,$(SRCDIR),$(eval $(call compile-objects,$(bdir))))
 
 .PHONY: calculate_unused_ram
 calculate_unused_ram: $(FAMILY).size $(LINKER)
-	@$(FIRMWARE_DIR)/calculate_unused_ram.sh $(FAMILY).size $(LINKER)
+	@"$(FIRMWARE_DIR)/calculate_unused_ram.sh" $(FAMILY).size $(LINKER)

--- a/gd32_rdm_responder/Makefile.GD32
+++ b/gd32_rdm_responder/Makefile.GD32
@@ -17,4 +17,4 @@ SRCDIR=firmware lib
 include ../firmware-template-gd32/Rules.mk
 
 prerequisites:
-	./generate_sofware_version_id.sh
+	@echo "constexpr uint32_t DEVICE_SOFTWARE_VERSION_ID="$(shell date "+%s")";" > ./include/sofware_version_id.h

--- a/gd32_rdm_responder/generate_sofware_version_id.sh
+++ b/gd32_rdm_responder/generate_sofware_version_id.sh
@@ -1,4 +1,0 @@
-echo "// Generated "$(date) > ./include/sofware_version_id.h
-var="$(date +%s)"
-echo "constexpr uint32_t DEVICE_SOFTWARE_VERSION_ID="$var";" >> ./include/sofware_version_id.h
-


### PR DESCRIPTION
Generate 'sofware_version_id.h' directly from Makefile, removing the need for shell script 'generate_sofware_version_id.sh'
Escape quote 'calculate_unused_ram.sh' shell script