### PR TITLE
Add Makefile defineable board name and ID

### DIFF
--- a/lib-gd32/include/board/gd32f303rc.h
+++ b/lib-gd32/include/board/gd32f303rc.h
@@ -161,6 +161,9 @@ static constexpr uint32_t PORT_A_TX = 0;
 
 #define GD32_MCU_NAME			"GD32F303RC"
 #define GD32_BOARD_NAME			"GD32F303RC"
+#if !defined(GD32_BOARD_ID)
+# define GD32_BOARD_ID			0
+#endif
 
 #include "mcu/gd32f30x_mcu.h"
 #include "gd32_gpio.h"

--- a/lib-gd32/include/board/gd32f303rc.h
+++ b/lib-gd32/include/board/gd32f303rc.h
@@ -160,7 +160,9 @@ static constexpr uint32_t PORT_A_TX = 0;
  */
 
 #define GD32_MCU_NAME			"GD32F303RC"
-#define GD32_BOARD_NAME			"GD32F303RC"
+#if !defined(GD32_BOARD_NAME)
+# define GD32_BOARD_NAME		"GD32F303RC"
+#endif
 #if !defined(GD32_BOARD_ID)
 # define GD32_BOARD_ID			0
 #endif

--- a/lib-hal/include/gd32/hardware.h
+++ b/lib-hal/include/gd32/hardware.h
@@ -150,7 +150,7 @@ public:
 	}
 
 	uint32_t GetBoardId() {
-		return 0;
+		return GD32_BOARD_ID;
 	}
 
 	const char *GetWebsiteUrl() {


### PR DESCRIPTION
• Adds the define GD32_BOARD_ID which is ultimately used for the RDM Device Model ID
• Allows GD32_BOARD_NAME , which is used for the RDM Device Model Description, to be overridden by the build environment