### PR TITLE
Use GCC MD/MP flags to Track Dependencies

### DIFF
--- a/firmware-template-gd32/lib/Rules.mk
+++ b/firmware-template-gd32/lib/Rules.mk
@@ -72,11 +72,13 @@ LIST=lib.list
 define compile-objects
 $(info $1)
 $(BUILD)$1/%.o: $1/%.c
-	$(CC) $(COPS) -c $$< -o $$@
-	
+	$(CC) -MD -MP $(COPS) -c $$< -o $$@
+
 $(BUILD)$1/%.o: $1/%.cpp
-	$(CPP) $(COPS) $(CPPOPS) -c $$< -o $$@
-	
+	$(CPP) -MD -MP $(COPS) $(CPPOPS) -c $$< -o $$@
+
+-include $(BUILD)$1/*.d
+
 $(BUILD)$1/%.o: $1/%.S
 	$(CC) $(COPS) -D__ASSEMBLY__ -c $$< -o $$@
 endef


### PR DESCRIPTION
I am working on a usage of this code that relies on modifying values in header files and recompiling. I noted that frequently a clean and rebuild is needed to pick up such changes.

In order to automatically track dependencies such as header files, use the GCC MD/MP flags to generate an included dependency list.

This ensures header dependencies are tracked to avoid stale builds or the necessity to clean between builds.